### PR TITLE
fix(credential): resolve config file path issue on Windows

### DIFF
--- a/tencentcloud/common/credential.py
+++ b/tencentcloud/common/credential.py
@@ -283,9 +283,8 @@ class ProfileCredential(object):
     """
 
     def get_credential(self):
-        home_path = os.environ.get('HOME') or os.environ.get('HOMEPATH')
-        if os.path.exists(home_path + "/.tencentcloud/credentials"):
-            file_path = home_path + "/.tencentcloud/credentials"
+        if os.path.exists(os.path.expanduser("~/.tencentcloud/credentials")):
+            file_path = os.path.expanduser("~/.tencentcloud/credentials")
         elif os.path.exists("/etc/tencentcloud/credentials"):
             file_path = "/etc/tencentcloud/credentials"
         else:


### PR DESCRIPTION
## Fix config file path resolution issue on Windows

### Problem Description
The current code using `os.environ.get('HOME') or os.environ.get('HOMEPATH')` to get user home directory has a bug on Windows:
- `HOMEPATH` environment variable typically contains only relative path (e.g., `\Users\username`) without drive letter
- When program runs from non-C drive, it cannot correctly locate `C:\Users\username\.tencentcloud\credentials` config file
- This causes ProfileCredential to fail reading user credential configuration

### Solution
Replace manual path concatenation with `os.path.expanduser("~/.tencentcloud/credentials")`:

### Changes Made
- Replace `home_path + "/.tencentcloud/credentials"` with `os.path.expanduser("~/.tencentcloud/credentials")`
- Maintain full compatibility with Linux/macOS systems